### PR TITLE
Add stm32f4xx-hal/fmpi2c1 feature to stm32f413, fix setup code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ panic-probe = { version = "0.2", features = ["print-rtt"] }
 [dev-dependencies]
 cortex-m-rt = ">=0.6.15, <0.8"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
-stm32f4xx-hal = {version = "0.13.2", features = ["stm32f412"]}
+stm32f4xx-hal = "0.13.2"
 panic-semihosting = "0.5.2"
 
 [profile.dev]
@@ -27,6 +27,4 @@ opt-level = "z"
 
 [features]
 stm32f412 = ["stm32f4xx-hal/stm32f412"]
-stm32f413 = ["stm32f4xx-hal/stm32f413"]
-i2c3 = []
-fmpi2c1 = []
+stm32f413 = ["stm32f4xx-hal/stm32f413", "stm32f4xx-hal/fmpi2c1"]


### PR DESCRIPTION
The breakthrough was figuring out that the stm32f413 has i2cfmp.

I notice that sometimes I have to reset the dev board with the black button (or re-flash the program) to make it work.
